### PR TITLE
Add ceylon.formatter to build path

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,5 +5,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="com.redhat.ceylon.eclipse.ui.cpcontainer.RUNTIME_CONTAINER/default"/>
 	<classpathentry kind="con" path="com.redhat.ceylon.eclipse.ui.cpcontainer.CEYLON_CONTAINER/default"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/ceylon.formatter"/>
 	<classpathentry kind="output" path="classes"/>
 </classpath>


### PR DESCRIPTION
This should improve the debugging experience, and makes sense in general.

However, I don’t know what this does if someone is using the IDE and has `ceylon.ast` but not `ceylon.formatter`. I suspect @sadmac7000 might have such a setup – could you perhaps test this?