### PR TITLE
support ceylon/ceylon-spec#891

### DIFF
--- a/source/ceylon/ast/redhat/Block.ceylon
+++ b/source/ceylon/ast/redhat/Block.ceylon
@@ -6,6 +6,9 @@ import com.redhat.ceylon.compiler.typechecker.tree {
     JNode=Node,
     Tree {
         JBlock=Block
+    },
+    CustomTree {
+      JGuardedVariable=GuardedVariable
     }
 }
 import ceylon.interop.java {
@@ -14,7 +17,7 @@ import ceylon.interop.java {
 
 "Converts a RedHat AST [[Block|JBlock]] to a `ceylon.ast` [[Block]]."
 shared Block blockToCeylon(JBlock block, Anything(JNode,Node) update = noop) {
-    value result = Block(CeylonIterable(block.statements).collect(propagateUpdate(declarationOrStatementToCeylon, update)));
+    value result = Block(CeylonIterable(block.statements).filter((d) => !d is JGuardedVariable).collect(propagateUpdate(declarationOrStatementToCeylon, update)));
     update(block, result);
     return result;
 }

--- a/source/ceylon/ast/redhat/ClassBody.ceylon
+++ b/source/ceylon/ast/redhat/ClassBody.ceylon
@@ -6,6 +6,9 @@ import com.redhat.ceylon.compiler.typechecker.tree {
     JNode=Node,
     Tree {
         JClassBody=ClassBody
+    },
+    CustomTree {
+      JGuardedVariable=GuardedVariable
     }
 }
 import ceylon.interop.java {
@@ -14,7 +17,7 @@ import ceylon.interop.java {
 
 "Converts a RedHat AST [[ClassBody|JClassBody]] to a `ceylon.ast` [[ClassBody]]."
 shared ClassBody classBodyToCeylon(JClassBody classBody, Anything(JNode,Node) update = noop) {
-    value result = ClassBody(CeylonIterable(classBody.statements).collect(propagateUpdate(declarationOrStatementToCeylon, update)));
+    value result = ClassBody(CeylonIterable(classBody.statements).filter((d) => !d is JGuardedVariable).collect(propagateUpdate(declarationOrStatementToCeylon, update)));
     update(classBody, result);
     return result;
 }


### PR DESCRIPTION
Blocks may now include synthetic `GuardedVariable`s, which should be ignored.