### PR TITLE
Fix logic when converting a Red Hat NamedArgument

### DIFF
--- a/source/ceylon/ast/redhat/AnonymousArgument.ceylon
+++ b/source/ceylon/ast/redhat/AnonymousArgument.ceylon
@@ -15,7 +15,7 @@ import com.redhat.ceylon.compiler.typechecker.tree {
  does not convert those and will throw an exception instead!"
 shared AnonymousArgument anonymousArgumentToCeylon(JSpecifiedArgument anonymousArgument, Anything(JNode,Node) update = noop) {
     "Must be anonymous"
-    assert (!anonymousArgument.identifier exists,
+    assert (!anonymousArgument.identifier?.mainToken exists,
         !anonymousArgument.specifierExpression.mainToken exists);
     value result = AnonymousArgument(expressionToCeylon(anonymousArgument.specifierExpression.expression, update));
     update(anonymousArgument, result);

--- a/source/ceylon/ast/redhat/NamedArgument.ceylon
+++ b/source/ceylon/ast/redhat/NamedArgument.ceylon
@@ -19,7 +19,7 @@ shared NamedArgument namedArgumentToCeylon(JNamedArgument namedArgument, Anythin
     assert (is JSpecifiedArgument|JTypedArgument namedArgument);
     switch (namedArgument)
     case (is JSpecifiedArgument) {
-        if (!namedArgument.identifier exists) {
+        if (!namedArgument.identifier?.mainToken exists) {
             // anonymous argument
             return anonymousArgumentToCeylon(namedArgument, update);
         } else {


### PR DESCRIPTION
The logic to distinguish between anonymous arguments and specified
arguments was using an `exists` test on the `identifier`. But the
typechecker includes an identifier even in the case of anonymous
arguments.

for https://github.com/ceylon/ceylon.ast/issues/95