### PR TITLE
initialize the extraInfo hashmap lazily

### DIFF
--- a/source/ceylon/ast/core/Node.ceylon
+++ b/source/ceylon/ast/core/Node.ceylon
@@ -44,7 +44,9 @@ shared abstract class Node()
      
      [gist]: https://gist.github.com/lucaswerkmeister/b95470259328dea550ad
      */
-    HashMap<String,Object> extraInfo = HashMap<String,Object>();
+    variable HashMap<String,Object>? extraInfoMemo = null;
+    HashMap<String,Object> extraInfo
+            => extraInfoMemo else (extraInfoMemo = HashMap<String,Object>());
     
     "Returns the additional information attached to this node
      using the given [[key]], if any."


### PR DESCRIPTION
This makes a meaningful improvement in `anyCompilationUnitToCeylon` performance when `extraInfo` is not being used: 851ms vs 1050ms in one test.